### PR TITLE
允许在桥接的view.xib中指定file‘s owner

### DIFF
--- a/XXNibBridge/XXNibBridge.h
+++ b/XXNibBridge/XXNibBridge.h
@@ -17,7 +17,7 @@
 + (UINib *)xx_nib;
 
 /// Load object of this class from IB file with SAME name
-+ (id)xx_loadFromNib;
++ (id)xx_loadFromNibWithOwner:(id)owner;
 
 /// Load UIViewController of this class from given storyboard name
 + (id/*UIViewController*/)xx_loadFromStoryboardNamed:(NSString *)name;
@@ -30,5 +30,9 @@
 /// Subclass override it to switch On/Off IB bridging.
 /// default -> NO
 + (BOOL)xx_shouldApplyNibBridging;
+
++ (Class)xx_ownerClass;
+
+- (id)owner;
 
 @end


### PR DESCRIPTION
1、桥接的`UIView`子类需要实现`+ (Class)xx_ownerClass`方法：

```
+ (Class)xx_ownerClass
{
    return [IHMRTInfoViewOwner class];
}
```

2、在`IHMRTInfoViewOwner`类中添加`IBOutlet`属性：

```
@interface IHMRTInfoViewOwner : NSObject

@property (weak, nonatomic) IBOutlet UILabel *numLabel;
@property (weak, nonatomic) IBOutlet UILabel *titleLabel;

@end
```

3、在xib文件中指定`file owner`的`class`为`IHMRTInfoViewOwner`，就可以连接属性了。

属性连接成功后，在vc中可以通过view.owner来访问view的属性。

```
owner = (IHMRTInfoViewOwner *)self.infoView.owner;
[owner setNum:@"0"];
[owner setTitle:@"title"];
```
