### PR TITLE
Fix crash when using 2.3.1 in UICollectionViews or similar

### DIFF
--- a/XXNibBridge/XXNibBridge.m
+++ b/XXNibBridge/XXNibBridge.m
@@ -71,6 +71,15 @@
     // Copy autolayout constrains.
     if (placeholderView.constraints.count > 0) {
         
+        // Capture the placeholderView until the end of the current run loop cycle.
+        // This is needed when a view is initialized within a layoutSubviews call
+        // (example: UICollectionView cells).
+        // In this case iOS still evaluates the placeholder constraint, which without
+        // the capture would have a dangling pointer on the `firstItem` property.
+        dispatch_async(dispatch_get_main_queue(), ^{
+          (void)placeholderView;
+        });
+        
         // We only need to copy "self" constraints (like width/height constraints)
         // from placeholder to real view
         for (NSLayoutConstraint *constraint in placeholderView.constraints) {


### PR DESCRIPTION
In certain cases (collection views just being one of them), view initialization takes place within a `layoutSubviews`  call.

-[UIView layoutSubviews] does some evaluation of constraints and seems to keep its own references to them. Therefore it is possible, that constraints of the placeholderView are being used, after we're done with view initialization.

As the `placeholderView` gets replaced it would previously be deallocated immediately. As NSLayoutConstraints only keep weak references on their items this lead to a dangling pointer on
the `firstItem` property.

This change asynchronously dispatches a block enclosing the `placeholderView`. This defers the deallocation of the `placeholderView` until the end of the current runloop cycle and allows the current layoutSubviews call to go through before.

Based on the suggestion by @fuaiyi
# 

Fixes #29 

Might fix other issues regarding the iOS 10 Update.

---

@sunnyxx Thanks for the English readme and in-code documentation.

Note to other users of the framework: Please keep GitHub communication (issues and comments) for open-source projects in English. English is not my mother tongue either, but using a common language makes collaboration a lot easier.
