### PR TITLE
Support of Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,17 +5,6 @@ import PackageDescription
 let package = Package(
     name: "XXNibBridge",
     platforms: [.iOS(.v8)],
-    products: [
-        .library(
-            name: "XXNibBridge",
-            targets: ["XXNibBridge"]
-        )
-    ],
-    targets: [
-        .target(
-            name: "XXNibBridge",
-            path: "XXNibBridge",
-            publicHeadersPath: "XXNibBridge"
-        )
-    ]
+    products: [.library(name: "XXNibBridge", targets: ["XXNibBridge"])],
+    targets: [.target(name: "XXNibBridge", path: "XXNibBridge")]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,11 @@ let package = Package(
     name: "XXNibBridge",
     platforms: [.iOS(.v8)],
     products: [
-        .library(name: "XXNibBridge", targets: ["XXNibBridge"])
+        .library(
+            name: "XXNibBridge",
+            type: .dynamic,
+            targets: ["XXNibBridge"]
+        )
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version:5.0
+
+import PackageDescription
+
+let package = Package(
+    name: "XXNibBridge",
+    platforms: [.iOS(.v8)],
+    products: [
+        .library(name: "XXNibBridge", targets: ["XXNibBridge"])
+    ],
+    targets: [
+        .target(
+            name: "XXNibBridge",
+            path: "XXNibBridge"
+        )
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -8,14 +8,14 @@ let package = Package(
     products: [
         .library(
             name: "XXNibBridge",
-            type: .dynamic,
             targets: ["XXNibBridge"]
         )
     ],
     targets: [
         .target(
             name: "XXNibBridge",
-            path: "XXNibBridge"
+            path: "XXNibBridge",
+            publicHeadersPath: "XXNibBridge"
         )
     ]
 )

--- a/XXNibBridge/include/XXNibBridge.h
+++ b/XXNibBridge/include/XXNibBridge.h
@@ -1,0 +1,25 @@
+// XXNibBridge.h
+// Version 2.2
+//
+// Copyright (c) 2015 sunnyxx ( http://github.com/sunnyxx )
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <../XXNibBridge.h>
+#import <../XXNibConvention.h>


### PR DESCRIPTION
Adds `Package.swift` file and umbrella header which enables usage with SPM.
**Note**, that the most correct usage with SPM will be possible only when there is new release that includes `Package.swift`. Until then, dependency can be added by branch or commit hash which is not allowed in published packages.